### PR TITLE
chore: optimize resource request and memory utilization

### DIFF
--- a/ci/openshift/limesurvey-bcgov.bc.yaml
+++ b/ci/openshift/limesurvey-bcgov.bc.yaml
@@ -47,11 +47,11 @@ objects:
       postCommit: {}
       resources:
         limits:
-          cpu: 1400m
-          memory: 500Mi
+          cpu: 1800m
+          memory: 750Mi
         requests:
-          cpu: 900m
-          memory: 400Mi
+          cpu: 1200m
+          memory: 500Mi
       runPolicy: SerialLatestOnly
 parameters:
   - name: NAME

--- a/ci/openshift/postgresql.dc.yaml
+++ b/ci/openshift/postgresql.dc.yaml
@@ -53,7 +53,7 @@ objects:
       resources:
         requests:
           storage: "${DB_VOLUME_CAPACITY}"
-      storageClassName: netapp-file-standard
+      storageClassName: netapp-block-standard
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:

--- a/ci/openshift/postgresql.dc.yaml
+++ b/ci/openshift/postgresql.dc.yaml
@@ -78,7 +78,7 @@ objects:
             from:
               kind: ImageStreamTag
               namespace: openshift
-              name: postgresql:14.4
+              name: postgresql:12
       replicas: 1
       revisionHistoryLimit: 10
       test: false


### PR DESCRIPTION
Currently, builds fail due to insufficient resources. Peak utilization during builds are captured in the graphs below, which is used to set the cpu and memory **request** values. **Limit** values are derived from 1.5 x **request** value.  

<img width="371" alt="image" src="https://user-images.githubusercontent.com/2048170/177189098-036a4d92-81d6-4002-a54c-118501518400.png">
<img width="356" alt="image" src="https://user-images.githubusercontent.com/2048170/177189138-a27dc4ae-a0e7-485e-931e-ba199395d580.png">

